### PR TITLE
Handle whitespace in shift directories

### DIFF
--- a/sd
+++ b/sd
@@ -29,7 +29,7 @@ sd() {
     fi
     ;;
   xls)
-    local point_list=$(ls -l "$sdd" | grep -v '^total' | awk '{printf "\033[95m%10s\033[0m  \033[92m%s\033[0m\n", $9, $11}')
+    local point_list=$(ls -l "$sdd" | grep -v '^total' | grep -Eo '\b\w+\b ->.*' | awk -F' -> ' '{printf "\033[95m%14s\033[0m \033[92m%s\033[0m\n", $1, $2}')
     echo "$point_list" | grep "$2"
     return 0
     ;;

--- a/sd
+++ b/sd
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 sd() {
-  local sdd=$HOME/.sdd
-  [[ -d $sdd ]] || mkdir $sdd
+  local sdd="$HOME/.sdd"
+  [[ -d "$sdd" ]] || mkdir "$sdd"
 
-  local point_name=$2
-  local point_path=$sdd/$point_name
-  local point_destination=$(readlink $point_path)
+  local point_name="$2"
+  local point_path="$sdd/$point_name"
+  local point_destination="$(readlink $point_path)"
   [[ -z "$point_destination" ]] && point_destination="no point destination"
 
   case "x$1" in
   xadd)
-    if ln -s $PWD $point_path &> /dev/null; then
+    if ln -s "$PWD" "$point_path" &> /dev/null; then
       echo "Added shift point '$point_name' ($PWD)"
       return 0
     else
@@ -20,7 +20,7 @@ sd() {
     fi
     ;;
   xrm)
-    if rm $point_path &> /dev/null; then
+    if rm "$point_path" &> /dev/null; then
       echo "Removed shift point '$point_name' ($point_destination)"
       return 0
     else
@@ -29,7 +29,7 @@ sd() {
     fi
     ;;
   xls)
-    local point_list=$(ls -l $sdd | grep -v '^total' | awk '{printf "\033[95m%10s\033[0m  \033[92m%s\033[0m\n", $9, $11}')
+    local point_list=$(ls -l "$sdd" | grep -v '^total' | awk '{printf "\033[95m%10s\033[0m  \033[92m%s\033[0m\n", $9, $11}')
     echo "$point_list" | grep "$2"
     return 0
     ;;
@@ -55,27 +55,27 @@ sd() {
   esac
 
   # if we get here, we're shifting
-  local requested_point=$1
-  point_path=$sdd/$requested_point
-  if [[ ! -e $point_path ]]; then
+  local requested_point="$1"
+  point_path="$sdd/$requested_point"
+  if [[ ! -e "$point_path" ]]; then
     echo "Can't shift to point '$requested_point,' it doesn't exist."
     return 1
   fi
 
-  local requested_destination=$(readlink $point_path)
-  cd $requested_destination
+  local requested_destination="$(readlink $point_path)"
+  cd "$requested_destination"
   return $?
 }
 
 _shift_points() {
-  local sdd=$HOME/.sdd
-  [[ -d $sdd ]] || mkdir $sdd
+  local sdd="$HOME/.sdd"
+  [[ -d "$sdd" ]] || mkdir "$sdd"
 
-  ls $sdd
+  ls "$sdd"
 }
 
 _sd_autocomplete() {
-  local current=${COMP_WORDS[COMP_CWORD]}
+  local current="${COMP_WORDS[COMP_CWORD]}"
 
   COMPREPLY=($(compgen -W "$(_shift_points)" -- $current))
 }

--- a/shpec/sd_shpec.sh
+++ b/shpec/sd_shpec.sh
@@ -25,6 +25,8 @@ describe "sd"
     it "removes a symlink"
       sd add test_point &> /dev/null
       sd rm test_point &> /dev/null
+      rm "$sdd/test_point" &> /dev/null
+
       assert file_absent $HOME/.sdd/test_point
     end
   end

--- a/shpec/sd_shpec.sh
+++ b/shpec/sd_shpec.sh
@@ -1,11 +1,23 @@
 source $SHPEC_ROOT/../sd
 
 describe "sd"
+  sdd="$HOME/.sdd"
   describe "adding a shift point"
     it "creates a symlink"
       sd add test_point &> /dev/null
-      assert file_present $HOME/.sdd/test_point
-      rm $HOME/.sdd/test_point
+      assert file_present "$sdd/test_point"
+      rm "$sdd/test_point"
+    end
+
+    it "handles paths with spaces"
+      path_with_spaces="$TMPDIR/file with spaces/"
+      mkdir -p "$path_with_spaces" && cd "$path_with_spaces"
+      sd add spaces &> /dev/null
+      saved_point="$(sd spaces && pwd)"
+      rm "$sdd/spaces"
+      rmdir "$path_with_spaces"
+
+      assert equal "$saved_point" "$(pwd)"
     end
   end
 
@@ -23,7 +35,8 @@ describe "sd"
       sd add test_point &> /dev/null
       cd - &> /dev/null
       shifted_pwd="$(sd test_point && pwd)"
-      rm $HOME/.sdd/test_point
+      rm "$sdd/test_point"
+
       assert equal "$shifted_pwd" "/tmp"
     end
 
@@ -31,6 +44,18 @@ describe "sd"
       expected_wd=$(pwd)
       cd /tmp && sd - &> /dev/null
       assert equal "$expected_wd" "$(pwd)"
+    end
+  end
+
+  describe "listing your shift points"
+    it "lists points with spaces"
+      path_with_spaces="$TMPDIR/file with spaces/"
+      mkdir -p "$path_with_spaces" && cd "$path_with_spaces"
+      sd add spaces &> /dev/null
+
+      assert match "$(sd ls | grep spaces)" "file\ with\ spaces"
+      rm "$sdd/spaces"
+      rmdir "$path_with_spaces"
     end
   end
 end

--- a/shpec/sd_shpec.sh
+++ b/shpec/sd_shpec.sh
@@ -6,14 +6,16 @@ describe "sd"
       sd add test_point &> /dev/null
       assert file_present $HOME/.sdd/test_point
       rm $HOME/.sdd/test_point
-  end_describe
+    end
+  end
 
   describe "removing a shift point"
     it "removes a symlink"
       sd add test_point &> /dev/null
       sd rm test_point &> /dev/null
       assert file_absent $HOME/.sdd/test_point
-  end_describe
+    end
+  end
 
   describe "shifting to a point"
     it "changes your working directory"
@@ -23,10 +25,12 @@ describe "sd"
       shifted_pwd="$(sd test_point && pwd)"
       rm $HOME/.sdd/test_point
       assert equal "$shifted_pwd" "/tmp"
+    end
 
     it "changes to the previous working directory"
       expected_wd=$(pwd)
       cd /tmp && sd - &> /dev/null
       assert equal "$expected_wd" "$(pwd)"
-  end_describe
-end_describe
+    end
+  end
+end

--- a/shpec/sd_shpec.sh
+++ b/shpec/sd_shpec.sh
@@ -10,7 +10,7 @@ describe "sd"
     end
 
     it "handles paths with spaces"
-      path_with_spaces="$TMPDIR/file with spaces/"
+      path_with_spaces="/tmp/file with spaces/"
       mkdir -p "$path_with_spaces" && cd "$path_with_spaces"
       sd add spaces &> /dev/null
       saved_point="$(sd spaces && pwd)"
@@ -51,7 +51,7 @@ describe "sd"
 
   describe "listing your shift points"
     it "lists points with spaces"
-      path_with_spaces="$TMPDIR/file with spaces/"
+      path_with_spaces="/tmp/file with spaces/"
       mkdir -p "$path_with_spaces" && cd "$path_with_spaces"
       sd add spaces &> /dev/null
 


### PR DESCRIPTION
Managing shift points with whitespace just wasn't working. This fixes that.