### PR TITLE
add the ability to use fzf on unknown points.

### DIFF
--- a/sd
+++ b/sd
@@ -115,8 +115,18 @@ sd() {
   point_path="$sdd/$requested_point"
 
   if [[ ! -L "$point_path" ]]; then
-    echo "Can't shift to point '$requested_point' because it doesn't exist."
-    return 1
+    if [ -z "$SD_USE_FZF" ]; then
+        echo "Can't shift to point '$requested_point' because it doesn't exist."
+        return 1
+    else
+        type fzf >/dev/null 2>&1 || {
+        echo  "Can't shift to point '$requested_point' because it doesn't exist."
+        echo  "Also fzf should be used instead, but fzf can't be found."
+        return 1
+        }
+        point_path="$sdd/$(find "$sdd" -maxdepth 1 -type l -printf "%f\n"|fzf -q "$*")"
+    fi
+
   fi
 
   local requested_destination="$(readlink $point_path)/$subpath"


### PR DESCRIPTION
# What?
This pullrequest allows `sd` to run [fzf](https://github.com/junegunn/fzf) on a non-found target.

# Why?
i use sd on several boxes with auto-generated targets.
E.g.: a webserver with a folder per vhost.
Often i don't remember if the folder is called example.com or www.example.com or even www.example.net (and the others are aliases).
The `sd` autocompletion can't help here.
with that feature i'm able to call `sd example` and get `fzf` prefiltered.



# How was it tested?

At this point in time: only by using it.

# Additional work for this pull request
I don't expect you to merge this pull request in it's current state.
This is the code i'm using, it's not tested and not documented.

If this change is okay for you to have, i would prefer to get familiar with `shpec`, write some tests, document that feature before that gets merged.

So, what do you think?

