### PR TITLE
Fix issue with ls alias breaking parsing

### DIFF
--- a/sd
+++ b/sd
@@ -83,7 +83,7 @@ sd() {
     fi
     ;;
   xls)
-    local point_list=$(ls -l "$sdd" | grep -v '^total' | grep -Eo '\b\w+\b ->.*' | awk -F' -> ' '{printf "\033[95m%14s\033[0m \033[92m%s\033[0m\n", $1, $2}')
+    local point_list=$(command ls -l "$sdd" | grep -v '^total' | grep -Eo '\b\w+\b ->.*' | awk -F' -> ' '{printf "\033[95m%14s\033[0m \033[92m%s\033[0m\n", $1, $2}')
     echo "$point_list" | grep "$2"
     return 0
     ;;

--- a/shpec/sd_shpec.sh
+++ b/shpec/sd_shpec.sh
@@ -81,5 +81,17 @@ describe "sd"
       rm "$sdd/spaces"
       rmdir "$path_with_spaces"
     end
+
+    it "works when ls is aliased"
+      sd add foo
+      shopt -s expand_aliases
+      alias ls="ls -F"
+
+      assert present "$(sd ls | grep foo)"
+
+      unalias ls
+      shopt -u expand_aliases
+      rm "$sdd/foo"
+    end
   end
 end


### PR DESCRIPTION
When ls is aliased to something else (say `ls -F`), the grep pattern doesn't match and `sd ls` doesn't return any output.  Using `command` prevents alias expansion and executes ls directly.